### PR TITLE
remove stitching_yx_chunk_size_factor in example

### DIFF
--- a/examples/ImageXpressSinglePlaneAcquisitionExample.py
+++ b/examples/ImageXpressSinglePlaneAcquisitionExample.py
@@ -33,7 +33,6 @@ def main():
             barcode="barcode",
         ),
         yx_binning=2,
-        stitching_yx_chunk_size_factor=2,
         warp_func=stitching_utils.translate_tiles_2d,
         fuse_func=stitching_utils.fuse_mean,
         client=distributed.Client(threads_per_worker=1, processes=False, n_workers=1),


### PR DESCRIPTION
Remove `stitching_yx_chunk_size_factor` from example as per [this comment](https://github.com/fmi-faim/faim-ipa/pull/124#issuecomment-2093762915). I had missed this in the inital rework of the example because it seems we were working on the example at the same time.