### PR TITLE
Fix single field issue in _compute_z_spacing

### DIFF
--- a/src/faim_ipa/hcs/imagexpress/StackAcquisition.py
+++ b/src/faim_ipa/hcs/imagexpress/StackAcquisition.py
@@ -76,7 +76,11 @@ class StackAcquisition(ImageXpressPlateAcquisition):
         channel_with_stack = np.sort(files[files["z"] == "2"]["channel"].unique())[0]
         subset = files[files["channel"] == channel_with_stack]
         subset = subset[subset["well"] == np.sort(subset["well"].unique())[0]]
-        subset = subset[subset["field"] == np.sort(subset["field"].unique())[0]]
+        first_field = np.sort(subset["field"].unique())[0]
+        if first_field is not None:
+            subset = subset[
+                subset["field"] == np.sort(subset["field"].unique())[0]
+            ]
 
         plane_positions = []
 

--- a/src/faim_ipa/hcs/imagexpress/StackAcquisition.py
+++ b/src/faim_ipa/hcs/imagexpress/StackAcquisition.py
@@ -78,9 +78,7 @@ class StackAcquisition(ImageXpressPlateAcquisition):
         subset = subset[subset["well"] == np.sort(subset["well"].unique())[0]]
         first_field = np.sort(subset["field"].unique())[0]
         if first_field is not None:
-            subset = subset[
-                subset["field"] == np.sort(subset["field"].unique())[0]
-            ]
+            subset = subset[subset["field"] == np.sort(subset["field"].unique())[0]]
 
         plane_positions = []
 

--- a/tests/hcs/imagexpress/test_ImageXpress.py
+++ b/tests/hcs/imagexpress/test_ImageXpress.py
@@ -355,3 +355,18 @@ def test_time_lapse_acquistion(time_lapse_acquisition: PlateAcquisition):
             assert tile.position.y in [0, 256]
             assert tile.position.x in [0]
             assert tile.shape == (256, 256)
+
+
+def test_single_field_stack_acquistion(stack_acquisition: PlateAcquisition):
+    # Regular z spacing in dataset
+    files = stack_acquisition._parse_files()
+    z_step = stack_acquisition._compute_z_spacing(files)
+    assert z_step == 5
+
+    # Select the subset of only a single field to process
+    files = files[files["field"] == "s1"]
+    # When only a single field is available per well, the files dataframe
+    # has it set to None
+    files["field"] = None
+    z_step = stack_acquisition._compute_z_spacing(files)
+    assert z_step == 5


### PR DESCRIPTION
Currently, when processing an ImageXpress dataset with a single field per well, the `StackAcquisition._compute_z_spacing` returns an error like:

```
faim_ipa/hcs/imagexpress/StackAcquisition.py", line 92, in _compute_z_spacing
    precision = -Decimal(str(plane_positions[0])).as_tuple().exponent
```

The reason being that the `_compute_z_spacing` filters for unique fields, but that filtering fails when fields aren't set (=> are None in the fields table).

A minor change to first check if there are any field of views before filtering the files list solves the problem and makes single field examples I have convertable. I don't have any tiny datasets to show the full workflow, but the newly added tests fail in the current faim-ipa version and pass with this minor adaptation.