### PR TITLE
CellVoyager: fix wavelength parsing

### DIFF
--- a/src/faim_ipa/hcs/cellvoyager/StackAcquisition.py
+++ b/src/faim_ipa/hcs/cellvoyager/StackAcquisition.py
@@ -1,5 +1,6 @@
 from os.path import exists, join
 from pathlib import Path
+import re
 from typing import Optional, Union
 from xml.etree import ElementTree as ET
 
@@ -50,7 +51,7 @@ class StackAcquisition(PlateAcquisition):
                 spatial_calibration_y=row["VerticalPixelDimension"],
                 spatial_calibration_units="um",
                 z_spacing=self.get_z_spacing(),
-                wavelength=row["Target"],
+                wavelength=self.__parse_filter_wavelength(row["Acquisition"]),
                 exposure_time=row["ExposureTime"],
                 exposure_time_unit="ms",
                 objective=row["Objective"],
@@ -77,6 +78,13 @@ class StackAcquisition(PlateAcquisition):
                 )
             )
         return wells
+
+    @staticmethod
+    def __parse_filter_wavelength(value) -> int:
+        try:
+            return int(re.match(r"BP(\d+)/", value).group(1))
+        except AttributeError:  # no cov
+            return 0
 
     def _parse_metadata(self) -> pd.DataFrame:
         mrf_file = join(self._acquisition_dir, "MeasurementDetail.mrf")

--- a/tests/hcs/cellvoyager/test_StackAcquisition.py
+++ b/tests/hcs/cellvoyager/test_StackAcquisition.py
@@ -35,7 +35,7 @@ def test_get_channel_metadata(cv_acquisition):
     assert ch_metadata[0].spatial_calibration_y == 0.325
     assert ch_metadata[0].spatial_calibration_units == "um"
     assert ch_metadata[0].z_spacing == 3.0
-    assert int(ch_metadata[0].wavelength) == 405
+    assert ch_metadata[0].wavelength == 445
     assert ch_metadata[0].exposure_time == 100
     assert ch_metadata[0].exposure_time_unit == "ms"
     assert ch_metadata[0].objective == "20x v2"
@@ -46,7 +46,7 @@ def test_get_channel_metadata(cv_acquisition):
     assert ch_metadata[1].spatial_calibration_y == 0.325
     assert ch_metadata[1].spatial_calibration_units == "um"
     assert ch_metadata[1].z_spacing == 3.0
-    assert int(ch_metadata[1].wavelength) == 488
+    assert ch_metadata[1].wavelength == 525
     assert ch_metadata[1].exposure_time == 100
     assert ch_metadata[1].exposure_time_unit == "ms"
     assert ch_metadata[1].objective == "20x v2"
@@ -57,7 +57,7 @@ def test_get_channel_metadata(cv_acquisition):
     assert ch_metadata[2].spatial_calibration_y == 0.325
     assert ch_metadata[2].spatial_calibration_units == "um"
     assert ch_metadata[2].z_spacing == 3.0
-    assert int(ch_metadata[2].wavelength) == 561
+    assert ch_metadata[2].wavelength == 600
     assert ch_metadata[2].exposure_time == 250
     assert ch_metadata[2].exposure_time_unit == "ms"
     assert ch_metadata[2].objective == "20x v2"
@@ -68,7 +68,7 @@ def test_get_channel_metadata(cv_acquisition):
     assert ch_metadata[3].spatial_calibration_y == 0.325
     assert ch_metadata[3].spatial_calibration_units == "um"
     assert ch_metadata[3].z_spacing == 3.0
-    assert int(ch_metadata[3].wavelength) == 640
+    assert ch_metadata[3].wavelength == 676
     assert ch_metadata[3].exposure_time == 250
     assert ch_metadata[3].exposure_time_unit == "ms"
     assert ch_metadata[3].objective == "20x v2"


### PR DESCRIPTION
We rely on 'Acquisition' instead of 'Target', as the latter can be an arbitrary string value.

Closes #152.