### PR TITLE
Update stitching_utils

### DIFF
--- a/src/faim_ipa/stitching/stitching_utils.py
+++ b/src/faim_ipa/stitching/stitching_utils.py
@@ -112,6 +112,8 @@ def translate_tiles_2d(
     if not all(tile.shape == tiles[0].shape for tile in tiles):
         raise ValueError("All tiles must have the same shape.")
     distance_mask = get_distance_mask(tiles[0].shape)
+    if distance_mask.ndim == 2:
+        distance_mask = distance_mask[np.newaxis, ...]
 
     warped_tiles = []
     warped_distance_masks = []
@@ -123,7 +125,6 @@ def translate_tiles_2d(
             tile_data = tile.load_data()
         if tile_data.ndim == 2:
             tile_data = tile_data[np.newaxis, ...]
-            distance_mask = distance_mask[np.newaxis, ...]
         warped_tile = shift_yx(chunk_zyx_origin, tile_data, tile_origin, chunk_shape)
         warped_distance_mask = shift_yx(
             chunk_zyx_origin, distance_mask, tile_origin, chunk_shape
@@ -139,7 +140,7 @@ def get_distance_mask(tile_shape):
     mask = np.zeros(tile_shape, dtype=bool)
     mask[..., 1:-1, 1:-1] = True
     distance_mask = distance_transform_cdt(mask, metric="taxicab") + 1
-    return distance_mask
+    return distance_mask.astype(np.uint16)
 
 
 def shift_yx(chunk_zyx_origin, tile_data, tile_origin, chunk_shape):

--- a/src/faim_ipa/stitching/stitching_utils.py
+++ b/src/faim_ipa/stitching/stitching_utils.py
@@ -195,7 +195,7 @@ def translate_tiles_2d(
 
     Returns
     -------
-        translated tiles, translated distance-masks
+        translated tiles, translated distance masks
     """
     array_location = block_info[None]["array-location"]
     chunk_zyx_origin = np.array(

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -2,19 +2,20 @@ from dataclasses import dataclass
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
-
 from faim_ipa.stitching import Tile
 from faim_ipa.stitching.stitching_utils import (
     assemble_chunk,
     fuse_linear,
     fuse_mean,
     fuse_sum,
+    get_distance_mask,
     shift_to_origin,
     shift_yx,
     translate_tiles_2d,
 )
 from faim_ipa.stitching.Tile import TilePosition
+from numpy.testing import assert_array_equal
+from scipy.ndimage import distance_transform_cdt
 
 
 @pytest.fixture
@@ -27,16 +28,18 @@ def tiles():
 
 
 @pytest.fixture
-def masks():
-    t1 = np.zeros((1, 10, 20), dtype=bool)
-    t1[:, :, :15] = True
-    t2 = np.zeros((1, 10, 20), dtype=bool)
-    t2[:, :, 5:] = True
+def distance_masks():
+    m1 = np.zeros((1, 10, 20), dtype=bool)
+    m1[:, :, :15] = True
+    t1 = distance_transform_cdt(m1, metric="taxicab")
+    m2 = np.zeros((1, 10, 20), dtype=bool)
+    m2[:, :, 5:] = True
+    t2 = distance_transform_cdt(m2, metric="taxicab")
     return np.array([t1, t2])
 
 
-def test_fuse_mean(tiles, masks):
-    fused_result = fuse_mean(warped_tiles=tiles, warped_masks=masks)
+def test_fuse_mean(tiles, distance_masks):
+    fused_result = fuse_mean(warped_tiles=tiles, warped_distance_masks=distance_masks)
     assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
     assert_array_equal(fused_result[:, :, :5], 1)
@@ -44,8 +47,8 @@ def test_fuse_mean(tiles, masks):
     assert_array_equal(fused_result[:, :, 15:], 4)
 
 
-def test_fuse_sum(tiles, masks):
-    fused_result = fuse_sum(warped_tiles=tiles, warped_masks=masks)
+def test_fuse_sum(tiles, distance_masks):
+    fused_result = fuse_sum(warped_tiles=tiles, warped_distance_masks=distance_masks)
     assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
     assert_array_equal(fused_result[:, :, :5], 1)
@@ -53,8 +56,8 @@ def test_fuse_sum(tiles, masks):
     assert_array_equal(fused_result[:, :, 15:], 4)
 
 
-def test_fuse_linear(tiles, masks):
-    fused_result = fuse_linear(warped_tiles=tiles, warped_masks=masks)
+def test_fuse_linear(tiles, distance_masks):
+    fused_result = fuse_linear(warped_tiles=tiles, warped_distance_masks=distance_masks)
     assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
     assert_array_equal(fused_result[:, :, :5], 1)
@@ -70,7 +73,9 @@ def test_fuse_linear(tiles, masks):
     assert_array_equal(fused_result[:, :, 14], int(1 * 1 / 11 + 4 * 10 / 11))
     assert_array_equal(fused_result[:, :, 15:], 4)
 
-    fused_result = fuse_linear(warped_tiles=tiles[:1], warped_masks=masks[:1])
+    fused_result = fuse_linear(
+        warped_tiles=tiles[:1], warped_distance_masks=distance_masks[:1]
+    )
     assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
     assert_array_equal(fused_result, tiles[0])
@@ -81,6 +86,7 @@ class DummyTile:
     def __init__(self, yx_position, data):
         self._yx_position = yx_position
         self._data = data
+        self.shape = data.shape
 
     def get_zyx_position(self):
         return (0,) + self._yx_position
@@ -185,6 +191,31 @@ def test_shift_to_origin():
     assert result[0].get_position() == (0, 0, 0, 0, 0)
 
 
+def test_get_distance_mask():
+    expected_distance_mask_2D = np.array(
+        [
+            [1, 1, 1, 1, 1, 1],
+            [1, 2, 2, 2, 2, 1],
+            [1, 2, 3, 3, 2, 1],
+            [1, 2, 2, 2, 2, 1],
+            [1, 1, 1, 1, 1, 1],
+        ],
+        dtype=np.uint16,
+    )
+
+    result = get_distance_mask((5, 6))
+    assert result.dtype == np.uint16
+    assert_array_equal(result, expected_distance_mask_2D)
+
+    result = get_distance_mask((1, 5, 6))
+    assert result.dtype == np.uint16
+    assert_array_equal(result, expected_distance_mask_2D.reshape((1, 5, 6)))
+
+    result = get_distance_mask((4, 5, 6))
+    assert result.dtype == np.uint16
+    assert_array_equal(result, np.stack([expected_distance_mask_2D for n in range(4)]))
+
+
 def test_translate_3d_tiles_2d(tiles):
     tile_map = {
         (0, 0, 0, 0, 0): [
@@ -215,7 +246,7 @@ def test_translate_3d_tiles_2d(tiles):
     assert warped_masks.shape == (2, 1, 10, 20)
 
     assert warped_tiles.dtype == np.uint16
-    assert warped_masks.dtype == bool
+    assert warped_masks.dtype == np.uint16
 
     assert_array_equal(warped_tiles[0], tiles[0])
     assert_array_equal(warped_tiles[1], tiles[1])
@@ -251,7 +282,7 @@ def test_translate_2d_tiles_2d(tiles):
     assert warped_masks.shape == (2, 1, 10, 20)
 
     assert warped_tiles.dtype == np.uint16
-    assert warped_masks.dtype == bool
+    assert warped_masks.dtype == np.uint16
 
     assert_array_equal(warped_tiles[0], tiles[0])
     assert_array_equal(warped_tiles[1], tiles[1])
@@ -288,7 +319,7 @@ def test_translate_2d_tiles_2d_data_mask(tiles):
     assert warped_masks.shape == (2, 1, 10, 20)
 
     assert warped_tiles.dtype == bool
-    assert warped_masks.dtype == bool
+    assert warped_masks.dtype == np.uint16
 
     assert_array_equal(warped_tiles[0], tiles[0] > 0)
     assert_array_equal(warped_tiles[1], tiles[1] > 0)
@@ -297,16 +328,15 @@ def test_translate_2d_tiles_2d_data_mask(tiles):
 def test_warp_yx():
     tile_data = np.ones((1, 3, 3))
     chunk_shape = (1, 3, 3)
-    warped_tile, warped_mask = shift_yx(
+    warped_tile = shift_yx(
         chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=tile_data,
         tile_origin=np.array((0, 0, 0)),
         chunk_shape=chunk_shape,
     )
     assert_array_equal(warped_tile, tile_data)
-    assert_array_equal(warped_mask, np.ones((1, 3, 3), dtype=bool))
 
-    warped_tile, warped_mask = shift_yx(
+    warped_tile = shift_yx(
         chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=tile_data,
         tile_origin=np.array((0, -1, -1)),
@@ -315,9 +345,8 @@ def test_warp_yx():
     expected_warped_tile = np.zeros_like(tile_data)
     expected_warped_tile[:, :-1, :-1] = 1
     assert_array_equal(warped_tile, expected_warped_tile)
-    assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = shift_yx(
+    warped_tile = shift_yx(
         chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=tile_data,
         tile_origin=np.array((0, 1, 1)),
@@ -326,9 +355,8 @@ def test_warp_yx():
     expected_warped_tile = np.zeros_like(tile_data)
     expected_warped_tile[:, 1:, 1:] = 1
     assert_array_equal(warped_tile, expected_warped_tile)
-    assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = shift_yx(
+    warped_tile = shift_yx(
         chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=np.ones((1, 1, 1)),
         tile_origin=np.array((0, 1, 1)),
@@ -337,9 +365,8 @@ def test_warp_yx():
     expected_warped_tile = np.zeros((1, 3, 3))
     expected_warped_tile[0, 1, 1] = 1
     assert_array_equal(warped_tile, expected_warped_tile)
-    assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = shift_yx(
+    warped_tile = shift_yx(
         chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=np.ones((1, 5, 5)),
         tile_origin=np.array((0, -1, -1)),
@@ -347,9 +374,8 @@ def test_warp_yx():
     )
     expected_warped_tile = np.ones((1, 3, 3))
     assert_array_equal(warped_tile, expected_warped_tile)
-    assert_array_equal(warped_mask, expected_warped_tile == 1)
 
-    warped_tile, warped_mask = shift_yx(
+    warped_tile = shift_yx(
         chunk_zyx_origin=np.array((0, 0, 0)),
         tile_data=np.ones((1, 5, 5)),
         tile_origin=np.array((0, 6, 0)),
@@ -357,4 +383,3 @@ def test_warp_yx():
     )
     expected_warped_tile = np.zeros((1, 3, 3))
     assert_array_equal(warped_tile, expected_warped_tile)
-    assert_array_equal(warped_mask, expected_warped_tile == 1)

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -110,7 +110,7 @@ def test_fuse_linear_random(tiles, distance_masks):
     )
     assert_array_equal(fused_result, expected_result)
 
-    fused_result = fuse_linear(
+    fused_result = fuse_linear_random(
         warped_tiles=tiles[:1], warped_distance_masks=distance_masks[:1]
     )
     assert fused_result.shape == (1, 10, 20)

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -6,7 +6,10 @@ from faim_ipa.stitching import Tile
 from faim_ipa.stitching.stitching_utils import (
     assemble_chunk,
     fuse_linear,
+    fuse_linear_random,
     fuse_mean,
+    fuse_overlay_bwd,
+    fuse_overlay_fwd,
     fuse_sum,
     get_distance_mask,
     shift_to_origin,
@@ -79,6 +82,60 @@ def test_fuse_linear(tiles, distance_masks):
     assert fused_result.shape == (1, 10, 20)
     assert fused_result.dtype == np.uint16
     assert_array_equal(fused_result, tiles[0])
+
+
+def test_fuse_linear_random(tiles, distance_masks):
+    fused_result = fuse_linear_random(
+        warped_tiles=tiles, warped_distance_masks=distance_masks
+    )
+    assert fused_result.shape == (1, 10, 20)
+    assert fused_result.dtype == np.uint16
+
+    expected_result = np.array(
+        [
+            [
+                [1, 1, 1, 1, 1, 1, 1, 4, 4, 1, 4, 4, 4, 4, 1, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 4, 1, 1, 1, 4, 4, 4, 1, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 1, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 4, 1, 4, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 1, 4, 1, 4, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 1, 4, 1, 4, 4, 1, 4, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 1, 4, 1, 4, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 1, 4, 1, 4, 1, 1, 1, 4, 4, 4, 4, 4, 4],
+                [1, 1, 1, 1, 1, 1, 1, 1, 4, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 4],
+            ]
+        ],
+        dtype=np.uint16,
+    )
+    assert_array_equal(fused_result, expected_result)
+
+    fused_result = fuse_linear(
+        warped_tiles=tiles[:1], warped_distance_masks=distance_masks[:1]
+    )
+    assert fused_result.shape == (1, 10, 20)
+    assert fused_result.dtype == np.uint16
+    assert_array_equal(fused_result, tiles[0])
+
+
+def test_fuse_overlay_fwd(tiles, distance_masks):
+    fused_result = fuse_overlay_fwd(
+        warped_tiles=tiles, warped_distance_masks=distance_masks
+    )
+    assert fused_result.shape == (1, 10, 20)
+    assert fused_result.dtype == np.uint16
+    assert_array_equal(fused_result[:, :, :5], 1)
+    assert_array_equal(fused_result[:, :, 5:], 4)
+
+
+def test_fuse_overlay_bwd(tiles, distance_masks):
+    fused_result = fuse_overlay_bwd(
+        warped_tiles=tiles, warped_distance_masks=distance_masks
+    )
+    assert fused_result.shape == (1, 10, 20)
+    assert fused_result.dtype == np.uint16
+    assert_array_equal(fused_result[:, :, :15], 1)
+    assert_array_equal(fused_result[:, :, 15:], 4)
 
 
 @dataclass

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -382,6 +382,34 @@ def test_translate_2d_tiles_2d_data_mask(tiles):
     assert_array_equal(warped_tiles[1], tiles[1] > 0)
 
 
+def test_translate_2d_shape_mismatch(tiles):
+    tile_map = {
+        (0, 0, 0, 0, 0): [
+            DummyTile(yx_position=(0, 0), data=tiles[0][0, ..., :15]),
+            DummyTile(yx_position=(0, 5), data=tiles[1][0, ..., 6:]),
+        ],
+        (1, 0, 0, 0, 0): [],
+    }
+
+    block_info = {
+        None: {
+            "array-location": [(0, 1), (0, 1), (0, 1), (0, 10), (0, 20)],
+            "chunk-location": (0, 0, 0, 0, 0),
+            "chunk-shape": (1, 1, 1, 10, 20),
+            "dtype": "uint16",
+            "num-chunks": (1, 1, 1, 1, 1),
+            "shape": (1, 1, 1, 10, 20),
+        }
+    }
+    with pytest.raises(ValueError):
+        translate_tiles_2d(
+            block_info=block_info,
+            chunk_shape=(1, 10, 20),
+            tiles=tile_map[(0, 0, 0, 0, 0)],
+            build_acquisition_mask=True,
+        )
+
+
 def test_warp_yx():
     tile_data = np.ones((1, 3, 3))
     chunk_shape = (1, 3, 3)


### PR DESCRIPTION
Fixes issues #154 #61 #62 and #63.

- The warp function now creates a `warped_distance_mask` instead of a simple boolean mask, which is then passed to the fuse function. This way, e.g. the `fuse_linear` function has all the necessary information needed for correct fusion, even if the chunk edge is at an overlapping region.
- Reworked and added fuse functions `fuse_linear_random`, `fuse_overlay_fwd` and `fuse_overlay_bwd`.