### PR TITLE
Plate conversion tweaks

### DIFF
--- a/src/faim_ipa/hcs/converter.py
+++ b/src/faim_ipa/hcs/converter.py
@@ -129,6 +129,7 @@ class ConvertToNGFFPlate:
         storage_options: dict | None = None,
         *,
         build_acquisition_mask: bool = False,
+        overwrite: bool = False,
     ):
         """
         Convert a plate acquisition to an NGFF plate.
@@ -147,6 +148,8 @@ class ConvertToNGFFPlate:
             Zarr storage options.
         build_acquisition_mask :
             Writes a boolean mask instead of the image data, indicating where the image data is present.
+        overwrite :
+            Overwrite existing data.
 
         Returns
         -------
@@ -173,12 +176,14 @@ class ConvertToNGFFPlate:
                 storage_options,
                 well_acquisition,
                 build_acquisition_mask=build_acquisition_mask,
+                overwrite=overwrite,
             )
             shapes, datasets = self._build_pyramid(
                 group,
                 chunks,
                 max_layer,
                 storage_options,
+                overwrite=overwrite,
             )
             self._write_metadata(
                 group, max_layer, shapes, datasets, plate_acquisition, well_acquisition
@@ -234,6 +239,7 @@ class ConvertToNGFFPlate:
         storage_options,
         well_acquisition,
         build_acquisition_mask,
+        overwrite,
     ):
         stitched_well_da = self._stitch_well_image(
             chunks,
@@ -256,6 +262,7 @@ class ConvertToNGFFPlate:
                         "compressor", zarr.storage.default_compressor
                     ),
                     dimension_separator=group._store._dimension_separator,
+                    overwrite=overwrite,
                 ),
             )
         )
@@ -277,6 +284,7 @@ class ConvertToNGFFPlate:
         chunks,
         max_layer,
         storage_options,
+        overwrite,
     ):
         image = da.from_zarr(url=group.store, component=str(Path(group.path, "0")))
         datasets = [{"path": "0"}]
@@ -305,6 +313,7 @@ class ConvertToNGFFPlate:
                             "compressor", zarr.storage.default_compressor
                         ),
                         dimension_separator=group._store._dimension_separator,
+                        overwrite=overwrite,
                     )
                 )
             )

--- a/src/faim_ipa/hcs/converter.py
+++ b/src/faim_ipa/hcs/converter.py
@@ -242,7 +242,6 @@ class ConvertToNGFFPlate:
         overwrite,
     ):
         stitched_well_da = self._stitch_well_image(
-            chunks,
             well_acquisition,
             output_shape=plate_acquisition.get_common_well_shape(),
             build_acquisition_mask=build_acquisition_mask,
@@ -343,7 +342,6 @@ class ConvertToNGFFPlate:
 
     def _stitch_well_image(
         self,
-        chunks,
         well_acquisition,
         output_shape: tuple[int, int, int, int, int],
         *,
@@ -351,21 +349,7 @@ class ConvertToNGFFPlate:
     ):
         from faim_ipa.stitching import DaskTileStitcher
 
-        tile_data_ndims = well_acquisition.get_tiles()[0].load_data().ndim
-        if tile_data_ndims == 2:
-            chunk_shape = (
-                chunks[-2],
-                chunks[-1],
-            )
-        elif tile_data_ndims == 3:
-            chunk_shape = (
-                chunks[-3],
-                chunks[-2],
-                chunks[-1],
-            )
-        else:  # pragma: no cover
-            msg = "Tile data must be 2D or 3D."
-            raise NotImplementedError(msg)
+        chunk_shape = well_acquisition.get_tiles()[0].shape
 
         stitcher = DaskTileStitcher(
             tiles=well_acquisition.get_tiles(),

--- a/src/faim_ipa/stitching/stitching_utils.py
+++ b/src/faim_ipa/stitching/stitching_utils.py
@@ -208,8 +208,6 @@ def translate_tiles_2d(
         msg = "All tiles must have the same shape."
         raise ValueError(msg)
     distance_mask = get_distance_mask(tiles[0].shape)
-    if distance_mask.ndim == 2:
-        distance_mask = distance_mask[np.newaxis, ...]
 
     warped_tiles = []
     warped_distance_masks = []
@@ -232,10 +230,14 @@ def translate_tiles_2d(
 
 
 def get_distance_mask(tile_shape):
-    mask = np.zeros(tile_shape, dtype=bool)
-    mask[..., 1:-1, 1:-1] = True
-    distance_mask = distance_transform_cdt(mask, metric="taxicab") + 1
-    return distance_mask.astype(np.uint16)
+    mask = np.zeros(tile_shape[-2:], dtype=bool)
+    mask[1:-1, 1:-1] = True
+    distance_mask = distance_transform_cdt(mask, metric="taxicab").astype(np.uint16) + 1
+    if len(tile_shape) == 3:
+        distance_mask = np.repeat(distance_mask[np.newaxis, ...], tile_shape[0], axis=0)
+    else:
+        distance_mask = distance_mask[np.newaxis]
+    return distance_mask
 
 
 def shift_yx(chunk_zyx_origin, tile_data, tile_origin, chunk_shape):

--- a/tests/hcs/test_converter.py
+++ b/tests/hcs/test_converter.py
@@ -216,7 +216,6 @@ def test__stitch_well_image_2d(plate_acquisition_2d, hcs_plate, client):
     converter = ConvertToNGFFPlate(hcs_plate, client=client)
     well_acquisition = plate_acquisition_2d.get_well_acquisitions()[0]
     well_img_da = converter._stitch_well_image(
-        chunks=(1, 1, 10, 1000, 1000),
         well_acquisition=well_acquisition,
         output_shape=plate_acquisition_2d.get_common_well_shape(),
         build_acquisition_mask=False,
@@ -230,7 +229,6 @@ def test__stitch_well_image_mask_2d(plate_acquisition_2d, hcs_plate, client):
     converter = ConvertToNGFFPlate(hcs_plate, client=client)
     well_acquisition = plate_acquisition_2d.get_well_acquisitions()[0]
     well_img_da = converter._stitch_well_image(
-        chunks=(1, 1, 10, 1000, 1000),
         well_acquisition=well_acquisition,
         output_shape=plate_acquisition_2d.get_common_well_shape(),
         build_acquisition_mask=True,
@@ -247,7 +245,6 @@ def test__stitch_well_image_3d(plate_acquisition, hcs_plate, client):
     )
     well_acquisition = plate_acquisition.get_well_acquisitions()[0]
     well_img_da = converter._stitch_well_image(
-        chunks=(1, 1, 10, 1000, 1000),
         well_acquisition=well_acquisition,
         output_shape=plate_acquisition.get_common_well_shape(),
         build_acquisition_mask=False,
@@ -264,7 +261,6 @@ def test__stitch_well_image_mask_3d(plate_acquisition, hcs_plate, client):
     )
     well_acquisition = plate_acquisition.get_well_acquisitions()[0]
     well_img_da = converter._stitch_well_image(
-        chunks=(1, 1, 10, 1000, 1000),
         well_acquisition=well_acquisition,
         output_shape=plate_acquisition.get_common_well_shape(),
         build_acquisition_mask=True,
@@ -282,7 +278,6 @@ def test__bin_yx(plate_acquisition, hcs_plate, client):
     )
     well_acquisition = plate_acquisition.get_well_acquisitions()[0]
     well_img_da = converter._stitch_well_image(
-        chunks=(1, 1, 10, 1000, 1000),
         well_acquisition=well_acquisition,
         output_shape=plate_acquisition.get_common_well_shape(),
         build_acquisition_mask=False,
@@ -397,7 +392,6 @@ def test__drop_missing_axes(plate_acquisition_2d, hcs_plate, client):
     converter = ConvertToNGFFPlate(hcs_plate, client=client)
     well_acquisition = plate_acquisition_2d.get_well_acquisitions()[0]
     well_img_da = converter._stitch_well_image(
-        chunks=(1, 1, 10, 1000, 1000),
         well_acquisition=well_acquisition,
         output_shape=plate_acquisition_2d.get_common_well_shape(),
         build_acquisition_mask=False,

--- a/tests/stitching/test_stitching_utils.py
+++ b/tests/stitching/test_stitching_utils.py
@@ -251,11 +251,13 @@ def test_shift_to_origin():
 def test_get_distance_mask():
     expected_distance_mask_2d = np.array(
         [
-            [1, 1, 1, 1, 1, 1],
-            [1, 2, 2, 2, 2, 1],
-            [1, 2, 3, 3, 2, 1],
-            [1, 2, 2, 2, 2, 1],
-            [1, 1, 1, 1, 1, 1],
+            [
+                [1, 1, 1, 1, 1, 1],
+                [1, 2, 2, 2, 2, 1],
+                [1, 2, 3, 3, 2, 1],
+                [1, 2, 2, 2, 2, 1],
+                [1, 1, 1, 1, 1, 1],
+            ]
         ],
         dtype=np.uint16,
     )
@@ -270,7 +272,9 @@ def test_get_distance_mask():
 
     result = get_distance_mask((4, 5, 6))
     assert result.dtype == np.uint16
-    assert_array_equal(result, np.stack([expected_distance_mask_2d for n in range(4)]))
+    assert_array_equal(
+        result, np.concatenate([expected_distance_mask_2d for n in range(4)])
+    )
 
 
 def test_translate_3d_tiles_2d(tiles):


### PR DESCRIPTION
* Add overwrite parameter to converter.
* Make it possible to provide `dtype` parameter, which reduces file-reading operations.
* Compute distance mask once per z-stack and repeat it along z.
* Refactor parsing code.

This PR changes some internal API and adds an optional parameter (`overwrite`) to the outward facing API. In line with past changes this would mean that we go to `faim-ipa-v0.7.0`.