### PR TITLE
Make date optional when parsing imagexpress data

### DIFF
--- a/src/faim_ipa/hcs/imagexpress/acquisition.py
+++ b/src/faim_ipa/hcs/imagexpress/acquisition.py
@@ -259,7 +259,7 @@ class SinglePlaneAcquisition(ImageXpressPlateAcquisition):
 
     def _get_root_re(self) -> re.Pattern:
         return re.compile(
-            r".*[\/\\](?P<date>\d{4}-\d{2}-\d{2})[\/\\](?P<acq_id>\d+)(?:[\/\\]TimePoint_(?P<t>\d+))?"
+            r".*(?:[\/\\](?P<date>\d{4}-\d{2}-\d{2}))?[\/\\](?P<acq_id>\d+)(?:[\/\\]TimePoint_(?P<t>\d+))?"
         )
 
     def _get_filename_re(self) -> re.Pattern:
@@ -320,7 +320,7 @@ class StackAcquisition(ImageXpressPlateAcquisition):
 
     def _get_root_re(self) -> re.Pattern:
         return re.compile(
-            r".*[\/\\](?P<date>\d{4}-\d{2}-\d{2})[\/\\](?P<acq_id>\d+)(?:[\/\\]TimePoint_(?P<t>\d+))?(?:[\/\\]ZStep_(?P<z>\d+))"
+            r".*(?:[\/\\](?P<date>\d{4}-\d{2}-\d{2}))?[\/\\](?P<acq_id>\d+)(?:[\/\\]TimePoint_(?P<t>\d+))?(?:[\/\\]ZStep_(?P<z>\d+))"
         )
 
     def _get_filename_re(self) -> re.Pattern:
@@ -422,7 +422,7 @@ class MixedAcquisition(StackAcquisition):
 
     def _get_root_re(self) -> re.Pattern:
         return re.compile(
-            r".*[\/\\](?P<date>\d{4}-\d{2}-\d{2})[\/\\](?P<acq_id>\d+)(?:[\/\\]TimePoint_(?P<t>\d+))?(?:[\/\\]ZStep_(?P<z>\d+))?.*"
+            r".*(?:[\/\\](?P<date>\d{4}-\d{2}-\d{2}))?[\/\\](?P<acq_id>\d+)(?:[\/\\]TimePoint_(?P<t>\d+))?(?:[\/\\]ZStep_(?P<z>\d+))?.*"
         )
 
     def _get_filename_re(self) -> re.Pattern:


### PR DESCRIPTION
When exporting data from the MD imagexpress at the ZMB, we usually don't have a folder with the date. Could we make the date optional when parsing the data?