### PR TITLE
Use forward slashes for relative paths in config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -76,7 +77,7 @@ exclude = [
 ]
 
 [[tool.hatch.envs.all.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.default]
 dependencies = [

--- a/src/faim_ipa/utils.py
+++ b/src/faim_ipa/utils.py
@@ -289,7 +289,7 @@ class IPAConfig(BaseModel):
     def path_relative_to_git(cls, value):
         if isinstance(value, Path):
             try:
-                return str(make_relative(value, cls.reference_dir()))
+                return make_relative(value, cls.reference_dir()).as_posix()
             except ValueError:
                 return str(value)
         return value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,10 +121,10 @@ def test_prompt_with_questionary(model, mocker, dummy_file):
     assert response.path == dummy_file
     assert response.model_dump() == {
         "boolean": True,
-        "directory": str(relpath(dummy_file.parent, Path.cwd())),
+        "directory": Path(relpath(dummy_file.parent, Path.cwd())).as_posix(),
         "ge0": 10,
         "number": 0.01,
-        "path": str(relpath(dummy_file, Path.cwd())),
+        "path": Path(relpath(dummy_file, Path.cwd())).as_posix(),
         "string": "text",
     }
 


### PR DESCRIPTION
By using `Path.as_posix()`, we ensure forward slashes independent of the platform.

This should help for interoperability between Windows and Linux systems.